### PR TITLE
fix #2 MQTT unexpected error with reason 32100

### DIFF
--- a/app/src/main/java/org/ttnmapper/phonesurveyor/services/MyService.kt
+++ b/app/src/main/java/org/ttnmapper/phonesurveyor/services/MyService.kt
@@ -179,8 +179,12 @@ class MyService : Service() {
                             MqttException.REASON_CODE_NOT_AUTHORIZED -> {
                                 setMQTTStatusMessage("MQTT failed to connect - not authorised")
                             }
+                            MqttException.REASON_CODE_CLIENT_CONNECTED -> {
+                                setMQTTStatusMessage("MQTT client connected")
+                                return
+                            }
                             else -> {
-                                setMQTTStatusMessage("MQTT failed to connect - unexpected error")
+                                setMQTTStatusMessage("MQTT failed to connect - unexpected error: " + errorReason)
                             }
                         }
                     } else {


### PR DESCRIPTION
This fix ignores the errorReason 32100 which means REASON_CODE_CLIENT_CONNECTED