### PR TITLE
Adding ACCESS_BACKGROUND_LOCATION feature for android 10 & 11

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application
         android:name=".SurveyorApp"


### PR DESCRIPTION
For Android 10 & 11 it is very usefull to get the permission ACCESS_BACKGROUND_LOCATION.
I test the code with an Android 9, 10 and 11 AVD.

For more informations see:
https://developer.android.com/training/location/permissions